### PR TITLE
Feature/TEAM2-23 회원가입 API 연결

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,39 @@
+import { api } from "./client";
+
+export type SignUpTermAgreement = {
+  termId: number;
+  agreed: boolean;
+};
+
+export interface SignUpUserInfo {
+  email: string; // <= 100
+  password: string; // 8~100
+  nickname: string; // 2~10
+  selfIntroduction?: string; // <= 300
+  signUpTermAgreements: SignUpTermAgreement[];
+}
+
+export interface SignUpPayload {
+  userInfo: SignUpUserInfo;
+  profileImage?: File | null; // 옵션
+}
+
+/**
+ * 회원가입 (multipart/form-data)
+ * - field "userInfo": JSON
+ * - field "profileImage": 파일(optional)
+ */
+export async function signUp(payload: SignUpPayload, signal?: AbortSignal) {
+  const fd = new FormData();
+
+  fd.append(
+    "userInfo",
+    new Blob([JSON.stringify(payload.userInfo)], { type: "application/json" }),
+  );
+
+  if (payload.profileImage) {
+    fd.append("profileImage", payload.profileImage);
+  }
+
+  await api.post("/v1/user/signup", fd, { signal });
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -43,7 +43,7 @@ export async function signUp(
 export async function checkNickname(
   nickname: string,
   signal?: AbortSignal,
-): Promise<"available" | "duplicate" | "invalid"> {
+): Promise<"available" | "duplicate" | "invalid" | "serverError"> {
   const res = await api.head(
     `/v1/user/nicknames/${encodeURIComponent(nickname)}`,
     {
@@ -55,6 +55,6 @@ export async function checkNickname(
   if (res.status === 204) return "available";
   if (res.status === 409) return "duplicate";
   if (res.status === 400) return "invalid";
-  // 나머지는 일단 invalid로 통일
+  if (res.status === 500) return "serverError";
   return "invalid";
 }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -33,3 +33,28 @@ export async function signUp(
 
   await api.post("/v1/user/signup", fd, { signal });
 }
+
+/**
+ * 닉네임 중복 확인
+ * - 204  -> 사용 가능
+ * - 409            -> 중복
+ * - 그 외          -> 에러
+ */
+export async function checkNickname(
+  nickname: string,
+  signal?: AbortSignal,
+): Promise<"available" | "duplicate" | "invalid"> {
+  const res = await api.head(
+    `/v1/user/nicknames/${encodeURIComponent(nickname)}`,
+    {
+      signal,
+      validateStatus: () => true,
+    },
+  );
+
+  if (res.status === 204) return "available";
+  if (res.status === 409) return "duplicate";
+  if (res.status === 400) return "invalid";
+  // 나머지는 일단 invalid로 통일
+  return "invalid";
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -18,18 +18,14 @@ export interface SignUpPayload {
   profileImage?: File | null; // 옵션
 }
 
-/**
- * 회원가입 (multipart/form-data)
- * - field "userInfo": JSON
- * - field "profileImage": 파일(optional)
- */
-export async function signUp(payload: SignUpPayload, signal?: AbortSignal) {
+export async function signUp(
+  payload: SignUpPayload,
+  signal?: AbortSignal,
+): Promise<void> {
   const fd = new FormData();
 
-  fd.append(
-    "userInfo",
-    new Blob([JSON.stringify(payload.userInfo)], { type: "application/json" }),
-  );
+  // 문자열 JSON으로 넣기
+  fd.append("userInfo", JSON.stringify(payload.userInfo));
 
   if (payload.profileImage) {
     fd.append("profileImage", payload.profileImage);

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -90,11 +90,11 @@ export default function SignUp() {
     return null;
   };
 
-  // ✅ 닉네임 중복 확인 핸들러
+  // 닉네임 중복 확인 핸들러
   const onCheckNickname = async () => {
     const name = nickname.trim();
     if (!nicknameRe.test(name)) {
-      setNickMsg("닉네임 형식이 올바르지 않습니다. (2~10자, 한영/숫자/_)");
+      setNickMsg("닉네임 형식이 올바르지 않습니다.");
       setNickAvailable(null);
       return;
     }
@@ -121,7 +121,6 @@ export default function SignUp() {
     }
   };
 
-  // async 핸들러는 유지
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -72,7 +72,8 @@ export default function SignUp() {
     return null;
   };
 
-  const onSubmit = async (e: React.FormEvent) => {
+  // async 핸들러는 유지
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
 
@@ -115,7 +116,12 @@ export default function SignUp() {
 
   return (
     <div className="signup-container">
-      <form className="signup-card" onSubmit={void onSubmit}>
+      <form
+        className="signup-card"
+        onSubmit={(e) => {
+          void onSubmit(e);
+        }}
+      >
         <div className="signup-logo">
           <Leaf className="signup-leaf-icon" />
           <h1 className="signup-title">GreenMate</h1>
@@ -125,6 +131,7 @@ export default function SignUp() {
           환경 운동가들을 위한 커뮤니티에 가입하세요
         </p>
 
+        {/* 닉네임 */}
         <div className="signup-field">
           <Label htmlFor="nickname" className="signup-label">
             닉네임
@@ -145,6 +152,7 @@ export default function SignUp() {
           </div>
         </div>
 
+        {/* 이메일 */}
         <div className="signup-field">
           <Label htmlFor="email" className="signup-label">
             이메일
@@ -161,6 +169,7 @@ export default function SignUp() {
           />
         </div>
 
+        {/* 비밀번호 */}
         <div className="signup-field">
           <Label htmlFor="password" className="signup-label">
             비밀번호
@@ -176,6 +185,7 @@ export default function SignUp() {
           />
         </div>
 
+        {/* 비밀번호 확인 */}
         <div className="signup-field">
           <Label htmlFor="passwordConfirm" className="signup-label">
             비밀번호 확인
@@ -191,6 +201,7 @@ export default function SignUp() {
           />
         </div>
 
+        {/* 자기소개 */}
         <div className="signup-field">
           <Label htmlFor="selfIntro" className="signup-label">
             자기소개(선택)
@@ -224,6 +235,7 @@ export default function SignUp() {
           </div>
         </div>
 
+        {/* 프로필 이미지 */}
         <div className="signup-field">
           <Label htmlFor="profileImage" className="signup-label">
             프로필 이미지
@@ -260,12 +272,14 @@ export default function SignUp() {
           )}
         </div>
 
+        {/* 에러 */}
         {error && (
           <div className="error" style={{ color: "#c62828" }}>
             에러: {error}
           </div>
         )}
 
+        {/* 제출 */}
         <Button type="submit" className="signup-submit" disabled={submitting}>
           {submitting ? "가입 중…" : "회원가입"}
         </Button>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -68,8 +68,17 @@ export default function SignUp() {
     setNickMsg(null);
   }, [nickname]);
 
-  const toggleAgreement = (id: number) =>
-    setAgreements((prev) => ({ ...prev, [id]: !prev[id] }));
+  const TERM_ID_SET = new Set(REQUIRED_TERMS.map((t) => t.id));
+
+  const toggleAgreement = (id: number) => {
+    setAgreements((prev) => {
+      if (!TERM_ID_SET.has(id)) {
+        console.warn("toggleAgreement: unknown term id:", id);
+        return prev; // 잘못된 id는 무시하자.
+      }
+      return { ...prev, [id]: !prev[id] };
+    });
+  };
 
   const validate = () => {
     if (!emailRe.test(email)) return "이메일 형식이 올바르지 않습니다.";
@@ -162,14 +171,14 @@ export default function SignUp() {
     }
   };
 
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    void onSubmit(e);
+  };
+
   return (
     <div className="signup-container">
-      <form
-        className="signup-card"
-        onSubmit={(e) => {
-          void onSubmit(e);
-        }}
-      >
+      <form className="signup-card" onSubmit={handleSubmit}>
         <div className="signup-logo">
           <Leaf className="signup-leaf-icon" />
           <h1 className="signup-title">GreenMate</h1>
@@ -208,7 +217,7 @@ export default function SignUp() {
           {nickMsg && (
             <div
               style={{
-                marginTop: 8,
+                marginTop: 3,
                 fontSize: 13,
                 color: nickAvailable ? "#1b5e20" : "#c62828",
               }}

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -15,9 +15,9 @@ const REQUIRED_TERMS = [
   { id: 2, label: "개인정보 수집/이용(필수)" },
 ];
 
-const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const nicknameRe = /^[\wㄱ-ㅎ가-힣]{2,10}$/; // 2~10자 한/영/숫자/_
-const passwordRe = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d!@#$%^&*]{8,100}$/;
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const nicknameRegex = /^[\wㄱ-ㅎ가-힣]{2,10}$/;
+const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d!@#$%^&*]{8,100}$/;
 
 export default function SignUp() {
   const nav = useNavigate();
@@ -81,15 +81,15 @@ export default function SignUp() {
   };
 
   const validate = () => {
-    if (!emailRe.test(email)) return "이메일 형식이 올바르지 않습니다.";
-    if (!nicknameRe.test(nickname))
+    if (!emailRegex.test(email)) return "이메일 형식이 올바르지 않습니다.";
+    if (!nicknameRegex.test(nickname))
       return "닉네임은 2~10자/한영숫자만 가능합니다.";
     if (nickAvailable === false && nickCheckedNick === nickname)
       return "이미 사용 중인 닉네임입니다.";
     if (nickAvailable !== true || nickCheckedNick !== nickname) {
       return "닉네임 중복 확인을 해주세요.";
     }
-    if (!passwordRe.test(password))
+    if (!passwordRegex.test(password))
       return "비밀번호는 영문+숫자를 포함하여 8자 이상이어야 합니다.";
     if (password !== passwordConfirm) return "비밀번호가 일치하지 않습니다.";
     for (const t of REQUIRED_TERMS) {
@@ -102,7 +102,7 @@ export default function SignUp() {
   // 닉네임 중복 확인 핸들러
   const onCheckNickname = async () => {
     const name = nickname.trim();
-    if (!nicknameRe.test(name)) {
+    if (!nicknameRegex.test(name)) {
       setNickMsg("닉네임 형식이 올바르지 않습니다.");
       setNickAvailable(null);
       return;

--- a/src/styles/SignUp.css
+++ b/src/styles/SignUp.css
@@ -97,7 +97,7 @@ html, body {
 }
 
 .signup-check-btn {
-  background-color: #6f6f6f;
+  background-color: #6d6d6d;
   color: white;
   padding: 0 0.75rem;
   height: 2rem;

--- a/src/styles/SignUp.css
+++ b/src/styles/SignUp.css
@@ -97,7 +97,7 @@ html, body {
 }
 
 .signup-check-btn {
-  background-color: #6d6d6d;
+  background-color: #a8a8a8;
   color: white;
   padding: 0 0.75rem;
   height: 2rem;

--- a/src/styles/SignUp.css
+++ b/src/styles/SignUp.css
@@ -97,7 +97,7 @@ html, body {
 }
 
 .signup-check-btn {
-  background-color: #a8a8a8;
+  background-color: #6f6f6f;
   color: white;
   padding: 0 0.75rem;
   height: 2rem;


### PR DESCRIPTION
### 개요
회원가입 API 연결

### 변경사항
- api/auth.ts 추가
- pages/SignUp.tsx 리팩터링: 
  - 폼 상태/검증 추가(이메일/닉네임/비밀번호, 자기소개 300자)
  - 닉네임 중복확인 버튼(사용 가능/불가 안내/재검증 요구)
  - 성공 시 알림 후 /login으로 네비게이션
- 후속 작업: 
  - 약관 목록 API 연동(현재 필수 2개 하드코딩)
  - 알림 UI를 alert -> 컴포넌트로 교체

### 리뷰어에게 하고 싶은 말
모두 화이팅입니다😺😺